### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
         default: 'npm run all'
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -26,3 +30,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: "${{ github.event.inputs.script }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
         default: 'npm run all'
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -26,6 +30,7 @@ jobs:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
       script: ${{inputs.script || 'npm run all'}}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -7,6 +7,10 @@ on:
         description: "Base branch to create the PR against"
         required: true
         default: "main"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: write
@@ -21,3 +25,4 @@ jobs:
       original-owner: "svenstaro"
       repo-name: "upload-release-action"
       base_branch: ${{ inputs.base_branch }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Upload files to a GitHub release [![GitHub Actions Workflow](https://github.com/step-security/upload-release-action/actions/workflows/e2e_test.yml/badge.svg)](https://github.com/step-security/upload-release-action/actions)
 
 This action allows you to select which files to upload to the just-tagged release.

--- a/action.yml
+++ b/action.yml
@@ -48,5 +48,5 @@ outputs:
   release_id:
     description: 'The ID of the draft release created.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -66,19 +66,39 @@ const uploadAssets = 'POST {origin}/repos/{owner}/{repo}/releases/{release_id}/a
 const deleteAssets = 'DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}';
 function validateSubscription() {
     return __awaiter(this, void 0, void 0, function* () {
-        var _a;
-        const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+        var _a, _b;
+        const eventPath = process.env.GITHUB_EVENT_PATH;
+        let repoPrivate;
+        if (eventPath && fs.existsSync(eventPath)) {
+            const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+            repoPrivate = (_a = eventData === null || eventData === void 0 ? void 0 : eventData.repository) === null || _a === void 0 ? void 0 : _a.private;
+        }
+        const upstream = 'svenstaro/upload-release-action';
+        const action = process.env.GITHUB_ACTION_REPOSITORY;
+        const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+        core.info('');
+        core.info('[1;36mStepSecurity Maintained Action[0m');
+        core.info(`Secure drop-in replacement for ${upstream}`);
+        if (repoPrivate === false)
+            core.info('[32m✓ Free for public repositories[0m');
+        core.info(`[36mLearn more:[0m ${docsUrl}`);
+        core.info('');
+        if (repoPrivate === false)
+            return;
+        const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+        const body = { action: action || '' };
+        if (serverUrl !== 'https://github.com')
+            body.ghes_server = serverUrl;
         try {
-            yield axios_1.default.get(API_URL, { timeout: 3000 });
+            yield axios_1.default.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
         }
         catch (error) {
-            if ((0, axios_1.isAxiosError)(error) && ((_a = error.response) === null || _a === void 0 ? void 0 : _a.status) === 403) {
-                core.error('Subscription is not valid. Reach out to support@stepsecurity.io');
+            if ((0, axios_1.isAxiosError)(error) && ((_b = error.response) === null || _b === void 0 ? void 0 : _b.status) === 403) {
+                core.error(`[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`);
+                core.error(`[31mLearn how to enable a subscription: ${docsUrl}[0m`);
                 process.exit(1);
             }
-            else {
-                core.info('Timeout or API not reachable. Continuing to next step.');
-            }
+            core.info('Timeout or API not reachable. Continuing to next step.');
         }
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,19 +27,46 @@ type UpdateReleaseResp = Endpoints[typeof updateRelease]['response']
 type UpdateReleaseParams = Endpoints[typeof updateRelease]['parameters']
 
 async function validateSubscription(): Promise<void> {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate: boolean | undefined
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData?.repository?.private
+  }
+
+  const upstream = 'svenstaro/upload-release-action'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('[1;36mStepSecurity Maintained Action[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false) core.info('[32m✓ Free for public repositories[0m')
+  core.info(`[36mLearn more:[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body: Record<string, string> = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
   try {
-    await axios.get(API_URL, {timeout: 3000})
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`
       )
+      core.error(`[31mLearn how to enable a subscription: ${docsUrl}[0m`)
       process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z